### PR TITLE
Implement Mobile Layout for Home

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -83,7 +83,8 @@ export default class App extends Vue {
 @import './variables.css';
 
 .application {
-  font-family: var(--font-sans-serif)!important;;
+  font-family: var(--font-sans-serif)!important;
+  font-size: 18px;
 }
 
 .application.theme--light {

--- a/src/components/Home.vue
+++ b/src/components/Home.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="demo home text-xs-center">
-    <v-img class="white--text" :src="require('@/assets/background.png')" height="600px" style="align-items: center">
-      <v-container>
+    <v-img class="banner" :src="require('@/assets/background.png')">
+      <v-container class="onnx-wrapper">
         <v-layout column justify-center align-center>
           <v-flex class="onnx">ONNX.JS</v-flex>
           <v-flex class="run-onnx">Run ONNX model in the browser</v-flex>
@@ -12,13 +12,13 @@
         </v-layout>
       </v-container>
     </v-img>
-    <div v-for="info in demoInfo" :key="info.path" style="width:100%; margin-top:30px">
-      <router-link :to="`/${info.path}`">
-        <div class="demo-card">
+    <div class="demo-card-wrapper">
+      <div v-for="info in demoInfo" :key="info.path" class="demo-card">
+        <router-link :to="`/${info.path}`">
           <div class="demo-card-image"><img :src="info.imagePath"/></div>
           <div class="demo-card-heading">{{ info.title }}</div>
-        </div>
-      </router-link>
+        </router-link>
+      </div>
     </div>
   </div>
 </template>
@@ -52,23 +52,25 @@ export default class HomePage extends Vue {
   width: 100%;
 }
 
+.demo-card-wrapper {
+  margin-top: 2rem;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
 .demo-card {
-  font-family: var(--font-sans-serif);
-  width: 100%;
+  width: 90%;
   max-width: 1000px;
+  font-family: var(--font-sans-serif);
   height: 90px;
-  margin: 30px auto;
   background: white;
   border: 1px solid whitesmoke;
   cursor: default;
   user-select: none;
-  display: inline-flex;
-  flex-direction: row;
-  align-items: center;
-  justify-content: space-between;
-  overflow: hidden;
   box-shadow: 3px 3px #062D5B;
   transition: box-shadow 0.2s ease-out;
+  margin-bottom: 1rem;
 
   &:first-child {
     margin-top: 0;
@@ -84,13 +86,17 @@ export default class HomePage extends Vue {
   }
 }
 
+.demo-card a {
+  display: flex;
+  align-items: center;
+}
+
 .demo-card-heading {
-  flex: 1;
-  padding: 20px;
-  text-align: center;
   color: var(--color-lightgray);
-  font-size: 18px;
+  flex: 1;
+  font-size: 1.1em;
   transition: color 0.2s ease-out;
+  text-align: center;
 }
 
 .demo-card-image {
@@ -102,20 +108,75 @@ export default class HomePage extends Vue {
   }
 }
 
+.banner {
+  color: white;
+  height: 33rem;
+}
+
+.onnx-wrapper {
+  margin-top: 5rem;
+}
+
 .onnx {
-  margin-top: 100px;
-  font-size: 50px;
+  font-size: 3em;
 }
 
 .run-onnx {
-  font-size: 30px;
+  font-size: 1.5em;
 }
 
 .onnx-info {
   font-family: var(--font-sans-serif-regular);
-  font-size: 18px;
-  width: 600px;
-  margin-top: 80px;
+  font-size: 1em;
+  margin-top: 5rem;
+}
+
+@media (max-width: 500px) {
+  .banner {
+    height: 10rem;
+  }
+
+  .onnx-wrapper {
+    padding: 0;
+    margin: 0;
+    background-color: rgba(0,0,0,0.5);
+  }
+
+  .onnx {
+    display: none;
+  }
+
+  .run-onnx {
+    font-size: 1em;
+    margin-top: 0.5rem;
+  }
+
+  .onnx-info {
+    margin-top: 0.5rem;
+    font-size: 0.8em;
+  }
+
+  .demo-card {
+    height: auto;
+  }
+
+  .demo-card a {
+    flex-direction: column;
+  }
+
+  .demo-card-heading {
+    margin: 1rem 0;
+  }
+
+  .demo-card-image  {
+    width: 100%;
+    height: auto;
+  }
+
+  .demo-card-image img {
+    width: 100%;
+    height: auto;
+  }
 }
 </style>
 


### PR DESCRIPTION
- Uses proper rem, em, for responsive sizing
- Creates a mobile view for the home page
- Change layout for the demo cards
- Make the image smaller on mobile

![image](https://user-images.githubusercontent.com/68524/49471712-6e3ce200-f7c2-11e8-9142-970d5af444fa.png)

vs

![image](https://user-images.githubusercontent.com/68524/49471724-74cb5980-f7c2-11e8-912d-7830577a31e9.png)
