### PR TITLE
data: Adding Scalar Tensor based op test cases

### DIFF
--- a/data/test/ops/abs.jsonc
+++ b/data/test/ops/abs.jsonc
@@ -55,6 +55,23 @@
             "type": "float32"
           }
         ]
+      },
+      {
+        "name": "Scalar",
+        "inputs": [
+          {
+            "data": [1],
+            "dims": [],
+            "type": "float32"
+          }
+        ],
+        "outputs": [
+          {
+            "data": [1],
+            "dims": [],
+            "type": "float32"
+          }
+        ]
       }
     ]
   }

--- a/data/test/ops/acos.jsonc
+++ b/data/test/ops/acos.jsonc
@@ -56,6 +56,23 @@
             "type": "float32"
           }
         ]
+      },
+      {
+        "name": "Scalar",
+        "inputs": [
+          {
+            "data": [0.1],
+            "dims": [],
+            "type": "float32"
+          }
+        ],
+        "outputs": [
+          {
+            "data": [1.4706],
+            "dims": [],
+            "type": "float32"
+          }
+        ]
       }
     ]
   }

--- a/data/test/ops/add.jsonc
+++ b/data/test/ops/add.jsonc
@@ -94,6 +94,76 @@
             "type": "float32"
           }
         ]
+      },
+      {
+        "name": "Scalar T[2,2]",
+        "inputs": [
+          {
+            "data": [1],
+            "dims": [],
+            "type": "float32"
+          },
+          {
+            "data": [
+              2,2,2,2
+            ],
+            "dims": [2,2],
+            "type":"float32"
+          }
+        ],
+        "outputs": [
+          {
+            "data": [3,3,3,3],
+            "dims": [2,2],
+            "type": "float32"
+          }
+        ]
+      },
+      {
+        "name": "T[2,2] Scalar",
+        "inputs": [
+          {
+            "data": [
+              2,2,2,2
+            ],
+            "dims": [2,2],
+            "type":"float32"
+          },
+          {
+            "data": [1],
+            "dims": [],
+            "type": "float32"
+          }
+        ],
+        "outputs": [
+          {
+            "data": [3,3,3,3],
+            "dims": [2,2],
+            "type": "float32"
+          }
+        ]
+      },
+      {
+        "name": "Scalar Scalar",
+        "inputs": [
+          {
+            "data": [1],
+            "dims": [],
+            "type":"float32"
+          },
+          {
+            "data": [1],
+            "dims": [],
+            "type": "float32"
+          }
+        ],
+        "outputs": [
+          {
+            "data": [2],
+            "dims": [],
+            "type": "float32"
+          }
+        ]
       }
     ]
   }

--- a/data/test/ops/and.jsonc
+++ b/data/test/ops/and.jsonc
@@ -48,6 +48,76 @@
             "type": "bool"
           }
         ]
+      },
+      {
+        "name": "Scalar T[2,2]",
+        "inputs": [
+          {
+            "data": [true],
+            "dims": [],
+            "type": "bool"
+          },
+          {
+            "data": [
+              false, false, false, false
+            ],
+            "dims": [2,2],
+            "type":"bool"
+          }
+        ],
+        "outputs": [
+          {
+            "data": [false, false, false, false],
+            "dims": [2,2],
+            "type": "bool"
+          }
+        ]
+      },
+      {
+        "name": "T[2,2] Scalar",
+        "inputs": [
+          {
+            "data": [
+              true, true, true, true
+            ],
+            "dims": [2,2],
+            "type":"bool"
+          },
+          {
+            "data": [false],
+            "dims": [],
+            "type": "bool"
+          }
+        ],
+        "outputs": [
+          {
+            "data": [false, false, false, false],
+            "dims": [2,2],
+            "type": "bool"
+          }
+        ]
+      },
+      {
+        "name": "Scalar Scalar",
+        "inputs": [
+          {
+            "data": [true],
+            "dims": [],
+            "type":"bool"
+          },
+          {
+            "data": [true],
+            "dims": [],
+            "type": "bool"
+          }
+        ],
+        "outputs": [
+          {
+            "data": [true],
+            "dims": [],
+            "type": "bool"
+          }
+        ]
       }
     ]
   }

--- a/data/test/ops/asin.jsonc
+++ b/data/test/ops/asin.jsonc
@@ -56,6 +56,23 @@
             "type": "float32"
           }
         ]
+      },
+      {
+        "name": "Scalar",
+        "inputs": [
+          {
+            "data": [0.1],
+            "dims": [],
+            "type": "float32"
+          }
+        ],
+        "outputs": [
+          {
+            "data": [0.10016742],
+            "dims": [],
+            "type": "float32"
+          }
+        ]
       }
     ]
   }

--- a/data/test/ops/ceil.jsonc
+++ b/data/test/ops/ceil.jsonc
@@ -55,6 +55,23 @@
             "type": "float32"
           }
         ]
+      },
+      {
+        "name": "Scalar",
+        "inputs": [
+          {
+            "data": [1.1],
+            "dims": [],
+            "type": "float32"
+          }
+        ],
+        "outputs": [
+          {
+            "data": [2],
+            "dims": [],
+            "type": "float32"
+          }
+        ]
       }
     ]
   }

--- a/data/test/ops/cos.jsonc
+++ b/data/test/ops/cos.jsonc
@@ -56,6 +56,23 @@
             "type": "float32"
           }
         ]
+      },
+      {
+        "name": "Scalar",
+        "inputs": [
+          {
+            "data": [0.1],
+            "dims": [],
+            "type": "float32"
+          }
+        ],
+        "outputs": [
+          {
+            "data": [0.99500417],
+            "dims": [],
+            "type": "float32"
+          }
+        ]
       }
     ]
   }

--- a/data/test/ops/div.jsonc
+++ b/data/test/ops/div.jsonc
@@ -96,6 +96,76 @@
             "type": "float32"
           }
         ]
+      },
+      {
+        "name": "Scalar T[2,2]",
+        "inputs": [
+          {
+            "data": [6],
+            "dims": [],
+            "type": "float32"
+          },
+          {
+            "data": [
+              2,2,2,2
+            ],
+            "dims": [2,2],
+            "type":"float32"
+          }
+        ],
+        "outputs": [
+          {
+            "data": [3,3,3,3],
+            "dims": [2,2],
+            "type": "float32"
+          }
+        ]
+      },
+      {
+        "name": "T[2,2] Scalar",
+        "inputs": [
+          {
+            "data": [
+              3,3,3,3
+            ],
+            "dims": [2,2],
+            "type":"float32"
+          },
+          {
+            "data": [1],
+            "dims": [],
+            "type": "float32"
+          }
+        ],
+        "outputs": [
+          {
+            "data": [3,3,3,3],
+            "dims": [2,2],
+            "type": "float32"
+          }
+        ]
+      },
+      {
+        "name": "Scalar Scalar",
+        "inputs": [
+          {
+            "data": [1],
+            "dims": [],
+            "type":"float32"
+          },
+          {
+            "data": [1],
+            "dims": [],
+            "type": "float32"
+          }
+        ],
+        "outputs": [
+          {
+            "data": [1],
+            "dims": [],
+            "type": "float32"
+          }
+        ]
       }
     ]
   }

--- a/data/test/ops/equal.jsonc
+++ b/data/test/ops/equal.jsonc
@@ -70,6 +70,76 @@
             "type": "bool"
           }
         ]
+      },
+      {
+        "name": "Scalar T[2,2]",
+        "inputs": [
+          {
+            "data": [1],
+            "dims": [],
+            "type": "float32"
+          },
+          {
+            "data": [
+              2,2,2,2
+            ],
+            "dims": [2,2],
+            "type":"float32"
+          }
+        ],
+        "outputs": [
+          {
+            "data": [false,false,false,false],
+            "dims": [2,2],
+            "type": "bool"
+          }
+        ]
+      },
+      {
+        "name": "T[2,2] Scalar",
+        "inputs": [
+          {
+            "data": [
+              2,2,2,2
+            ],
+            "dims": [2,2],
+            "type":"float32"
+          },
+          {
+            "data": [2],
+            "dims": [],
+            "type": "float32"
+          }
+        ],
+        "outputs": [
+          {
+            "data": [true, true, true, true],
+            "dims": [2,2],
+            "type": "bool"
+          }
+        ]
+      },
+      {
+        "name": "Scalar Scalar",
+        "inputs": [
+          {
+            "data": [1],
+            "dims": [],
+            "type":"float32"
+          },
+          {
+            "data": [1],
+            "dims": [],
+            "type": "float32"
+          }
+        ],
+        "outputs": [
+          {
+            "data": [true],
+            "dims": [],
+            "type": "bool"
+          }
+        ]
       }
     ]
   }

--- a/data/test/ops/exp.jsonc
+++ b/data/test/ops/exp.jsonc
@@ -56,6 +56,23 @@
             "type": "float32"
           }
         ]
+      },
+      {
+        "name": "Scalar",
+        "inputs": [
+          {
+            "data": [1],
+            "dims": [],
+            "type": "float32"
+          }
+        ],
+        "outputs": [
+          {
+            "data": [2.71828183],
+            "dims": [],
+            "type": "float32"
+          }
+        ]
       }
     ]
   }

--- a/data/test/ops/floor.jsonc
+++ b/data/test/ops/floor.jsonc
@@ -55,6 +55,23 @@
             "type": "float32"
           }
         ]
+      },
+      {
+        "name": "Scalar",
+        "inputs": [
+          {
+            "data": [1.1],
+            "dims": [],
+            "type": "float32"
+          }
+        ],
+        "outputs": [
+          {
+            "data": [1],
+            "dims": [],
+            "type": "float32"
+          }
+        ]
       }
     ]
   }

--- a/data/test/ops/greater.jsonc
+++ b/data/test/ops/greater.jsonc
@@ -70,6 +70,76 @@
             "type": "bool"
           }
         ]
+      },
+      {
+        "name": "Scalar T[2,2]",
+        "inputs": [
+          {
+            "data": [1],
+            "dims": [],
+            "type": "float32"
+          },
+          {
+            "data": [
+              2,2,2,2
+            ],
+            "dims": [2,2],
+            "type":"float32"
+          }
+        ],
+        "outputs": [
+          {
+            "data": [false, false, false, false],
+            "dims": [2,2],
+            "type": "bool"
+          }
+        ]
+      },
+      {
+        "name": "T[2,2] Scalar",
+        "inputs": [
+          {
+            "data": [
+              2,2,2,2
+            ],
+            "dims": [2,2],
+            "type":"float32"
+          },
+          {
+            "data": [1],
+            "dims": [],
+            "type": "float32"
+          }
+        ],
+        "outputs": [
+          {
+            "data": [true, true, true, true],
+            "dims": [2,2],
+            "type": "bool"
+          }
+        ]
+      },
+      {
+        "name": "Scalar Scalar",
+        "inputs": [
+          {
+            "data": [1],
+            "dims": [],
+            "type":"float32"
+          },
+          {
+            "data": [1],
+            "dims": [],
+            "type": "float32"
+          }
+        ],
+        "outputs": [
+          {
+            "data": [false],
+            "dims": [],
+            "type": "bool"
+          }
+        ]
       }
     ]
   }

--- a/data/test/ops/leaky-relu.jsonc
+++ b/data/test/ops/leaky-relu.jsonc
@@ -47,6 +47,23 @@
             "type": "float32"
           }
         ]
+      },
+      {
+        "name": "Scalar",
+        "inputs": [
+          {
+            "data": [-1.0],
+            "dims": [],
+            "type": "float32"
+          }
+        ],
+        "outputs": [
+          {
+            "data": [-0.05],
+            "dims": [],
+            "type": "float32"
+          }
+        ]
       }
     ]
   }

--- a/data/test/ops/less.jsonc
+++ b/data/test/ops/less.jsonc
@@ -70,6 +70,76 @@
             "type": "bool"
           }
         ]
+      },
+      {
+        "name": "Scalar T[2,2]",
+        "inputs": [
+          {
+            "data": [1],
+            "dims": [],
+            "type": "float32"
+          },
+          {
+            "data": [
+              2,2,2,2
+            ],
+            "dims": [2,2],
+            "type":"float32"
+          }
+        ],
+        "outputs": [
+          {
+            "data": [true, true, true, true],
+            "dims": [2,2],
+            "type": "bool"
+          }
+        ]
+      },
+      {
+        "name": "T[2,2] Scalar",
+        "inputs": [
+          {
+            "data": [
+              2,2,2,2
+            ],
+            "dims": [2,2],
+            "type":"float32"
+          },
+          {
+            "data": [1],
+            "dims": [],
+            "type": "float32"
+          }
+        ],
+        "outputs": [
+          {
+            "data": [false, false, false, false],
+            "dims": [2,2],
+            "type": "bool"
+          }
+        ]
+      },
+      {
+        "name": "Scalar Scalar",
+        "inputs": [
+          {
+            "data": [1],
+            "dims": [],
+            "type":"float32"
+          },
+          {
+            "data": [1],
+            "dims": [],
+            "type": "float32"
+          }
+        ],
+        "outputs": [
+          {
+            "data": [false],
+            "dims": [],
+            "type": "bool"
+          }
+        ]
       }
     ]
   }

--- a/data/test/ops/log.jsonc
+++ b/data/test/ops/log.jsonc
@@ -56,6 +56,23 @@
             "type": "float32"
           }
         ]
+      },
+      {
+        "name": "Scalar",
+        "inputs": [
+          {
+            "data": [1],
+            "dims": [],
+            "type": "float32"
+          }
+        ],
+        "outputs": [
+          {
+            "data": [0],
+            "dims": [],
+            "type": "float32"
+          }
+        ]
       }
     ]
   }

--- a/data/test/ops/mul.jsonc
+++ b/data/test/ops/mul.jsonc
@@ -95,6 +95,77 @@
           }
         ]
       }
+      ,
+      {
+        "name": "Scalar T[2,2]",
+        "inputs": [
+          {
+            "data": [1],
+            "dims": [],
+            "type": "float32"
+          },
+          {
+            "data": [
+              2,2,2,2
+            ],
+            "dims": [2,2],
+            "type":"float32"
+          }
+        ],
+        "outputs": [
+          {
+            "data": [2,2,2,2],
+            "dims": [2,2],
+            "type": "float32"
+          }
+        ]
+      },
+      {
+        "name": "T[2,2] Scalar",
+        "inputs": [
+          {
+            "data": [
+              2,2,2,2
+            ],
+            "dims": [2,2],
+            "type":"float32"
+          },
+          {
+            "data": [1],
+            "dims": [],
+            "type": "float32"
+          }
+        ],
+        "outputs": [
+          {
+            "data": [2,2,2,2],
+            "dims": [2,2],
+            "type": "float32"
+          }
+        ]
+      },
+      {
+        "name": "Scalar Scalar",
+        "inputs": [
+          {
+            "data": [1],
+            "dims": [],
+            "type":"float32"
+          },
+          {
+            "data": [1],
+            "dims": [],
+            "type": "float32"
+          }
+        ],
+        "outputs": [
+          {
+            "data": [1],
+            "dims": [],
+            "type": "float32"
+          }
+        ]
+      }
     ]
   }
 ]

--- a/data/test/ops/neg.jsonc
+++ b/data/test/ops/neg.jsonc
@@ -55,6 +55,23 @@
             "type": "float32"
           }
         ]
+      },
+      {
+        "name": "Scalar",
+        "inputs": [
+          {
+            "data": [1],
+            "dims": [],
+            "type": "float32"
+          }
+        ],
+        "outputs": [
+          {
+            "data": [-1],
+            "dims": [],
+            "type": "float32"
+          }
+        ]
       }
     ]
   }

--- a/data/test/ops/not.jsonc
+++ b/data/test/ops/not.jsonc
@@ -55,6 +55,23 @@
             "type": "bool"
           }
         ]
+      },
+      {
+        "name": "Scalar",
+        "inputs": [
+          {
+            "data": [true],
+            "dims": [],
+            "type": "bool"
+          }
+        ],
+        "outputs": [
+          {
+            "data": [false],
+            "dims": [],
+            "type": "bool"
+          }
+        ]
       }
     ]
   }

--- a/data/test/ops/or.jsonc
+++ b/data/test/ops/or.jsonc
@@ -48,6 +48,76 @@
             "type": "bool"
           }
         ]
+      },
+      {
+        "name": "Scalar T[2,2]",
+        "inputs": [
+          {
+            "data": [true],
+            "dims": [],
+            "type": "bool"
+          },
+          {
+            "data": [
+              false, false, false, false
+            ],
+            "dims": [2,2],
+            "type":"bool"
+          }
+        ],
+        "outputs": [
+          {
+            "data": [true, true, true, true],
+            "dims": [2,2],
+            "type": "bool"
+          }
+        ]
+      },
+      {
+        "name": "T[2,2] Scalar",
+        "inputs": [
+          {
+            "data": [
+              true, true, true, true
+            ],
+            "dims": [2,2],
+            "type":"bool"
+          },
+          {
+            "data": [false],
+            "dims": [],
+            "type": "bool"
+          }
+        ],
+        "outputs": [
+          {
+            "data": [true, true, true, true],
+            "dims": [2,2],
+            "type": "bool"
+          }
+        ]
+      },
+      {
+        "name": "Scalar Scalar",
+        "inputs": [
+          {
+            "data": [true],
+            "dims": [],
+            "type":"bool"
+          },
+          {
+            "data": [true],
+            "dims": [],
+            "type": "bool"
+          }
+        ],
+        "outputs": [
+          {
+            "data": [true],
+            "dims": [],
+            "type": "bool"
+          }
+        ]
       }
     ]
   }

--- a/data/test/ops/pow.jsonc
+++ b/data/test/ops/pow.jsonc
@@ -94,6 +94,76 @@
             "type": "float32"
           }
         ]
+      },
+      {
+        "name": "Scalar T[2,2]",
+        "inputs": [
+          {
+            "data": [1],
+            "dims": [],
+            "type": "float32"
+          },
+          {
+            "data": [
+              2,2,2,2
+            ],
+            "dims": [2,2],
+            "type":"float32"
+          }
+        ],
+        "outputs": [
+          {
+            "data": [1,1,1,1],
+            "dims": [2,2],
+            "type": "float32"
+          }
+        ]
+      },
+      {
+        "name": "T[2,2] Scalar",
+        "inputs": [
+          {
+            "data": [
+              2,2,2,2
+            ],
+            "dims": [2,2],
+            "type":"float32"
+          },
+          {
+            "data": [1],
+            "dims": [],
+            "type": "float32"
+          }
+        ],
+        "outputs": [
+          {
+            "data": [2,2,2,2],
+            "dims": [2,2],
+            "type": "float32"
+          }
+        ]
+      },
+      {
+        "name": "Scalar Scalar",
+        "inputs": [
+          {
+            "data": [3],
+            "dims": [],
+            "type":"float32"
+          },
+          {
+            "data": [2],
+            "dims": [],
+            "type": "float32"
+          }
+        ],
+        "outputs": [
+          {
+            "data": [9],
+            "dims": [],
+            "type": "float32"
+          }
+        ]
       }
     ]
   }

--- a/data/test/ops/relu.jsonc
+++ b/data/test/ops/relu.jsonc
@@ -21,6 +21,23 @@
             "type": "float32"
           }
         ]
+      },
+      {
+        "name": "Scalar",
+        "inputs": [
+          {
+            "data": [1.0],
+            "dims": [],
+            "type": "float32"
+          }
+        ],
+        "outputs": [
+          {
+            "data": [1.0],
+            "dims": [],
+            "type": "float32"
+          }
+        ]
       }
     ]
   }

--- a/data/test/ops/reshape.jsonc
+++ b/data/test/ops/reshape.jsonc
@@ -26,6 +26,72 @@
             "type": "float32"
           }
         ]
+      },
+      {
+        "name": "Scalar to 1D",
+        "inputs": [
+          {
+            "data": [1],
+            "dims": [],
+            "type": "float32"
+          },
+          {
+            "data": [1],
+            "dims": [1],
+            "type": "int32"
+          }
+        ],
+        "outputs": [
+          {
+            "data": [1],
+            "dims": [1],
+            "type": "float32"
+          }
+        ]
+      },
+      {
+        "name": "Scalar to 2D",
+        "inputs": [
+          {
+            "data": [1],
+            "dims": [],
+            "type": "float32"
+          },
+          {
+            "data": [1,1],
+            "dims": [2],
+            "type": "int32"
+          }
+        ],
+        "outputs": [
+          {
+            "data": [1],
+            "dims": [1,1],
+            "type": "float32"
+          }
+        ]
+      },
+      {
+        "name": "Scalar to 2D with -1 in shape hints",
+        "inputs": [
+          {
+            "data": [1],
+            "dims": [],
+            "type": "float32"
+          },
+          {
+            "data": [-1,1],
+            "dims": [2],
+            "type": "int32"
+          }
+        ],
+        "outputs": [
+          {
+            "data": [1],
+            "dims": [1,1],
+            "type": "float32"
+          }
+        ]
       }
     ]
   }

--- a/data/test/ops/sin.jsonc
+++ b/data/test/ops/sin.jsonc
@@ -56,6 +56,23 @@
             "type": "float32"
           }
         ]
+      },
+      {
+        "name": "Scalar",
+        "inputs": [
+          {
+            "data": [0.1],
+            "dims": [],
+            "type": "float32"
+          }
+        ],
+        "outputs": [
+          {
+            "data": [0.0998],
+            "dims": [],
+            "type": "float32"
+          }
+        ]
       }
     ]
   }

--- a/data/test/ops/sub.jsonc
+++ b/data/test/ops/sub.jsonc
@@ -94,6 +94,76 @@
             "type": "float32"
           }
         ]
+      },
+      {
+        "name": "Scalar T[2,2]",
+        "inputs": [
+          {
+            "data": [1],
+            "dims": [],
+            "type": "float32"
+          },
+          {
+            "data": [
+              2,2,2,2
+            ],
+            "dims": [2,2],
+            "type":"float32"
+          }
+        ],
+        "outputs": [
+          {
+            "data": [-1,-1,-1,-1],
+            "dims": [2,2],
+            "type": "float32"
+          }
+        ]
+      },
+      {
+        "name": "T[2,2] Scalar",
+        "inputs": [
+          {
+            "data": [
+              2,2,2,2
+            ],
+            "dims": [2,2],
+            "type":"float32"
+          },
+          {
+            "data": [1],
+            "dims": [],
+            "type": "float32"
+          }
+        ],
+        "outputs": [
+          {
+            "data": [1,1,1,1],
+            "dims": [2,2],
+            "type": "float32"
+          }
+        ]
+      },
+      {
+        "name": "Scalar Scalar",
+        "inputs": [
+          {
+            "data": [1],
+            "dims": [],
+            "type":"float32"
+          },
+          {
+            "data": [1],
+            "dims": [],
+            "type": "float32"
+          }
+        ],
+        "outputs": [
+          {
+            "data": [0],
+            "dims": [],
+            "type": "float32"
+          }
+        ]
       }
     ]
   }

--- a/data/test/ops/tan.jsonc
+++ b/data/test/ops/tan.jsonc
@@ -56,6 +56,23 @@
             "type": "float32"
           }
         ]
+      },
+      {
+        "name": "Scalar",
+        "inputs": [
+          {
+            "data": [0.1],
+            "dims": [],
+            "type": "float32"
+          }
+        ],
+        "outputs": [
+          {
+            "data": [0.10033467],
+            "dims": [],
+            "type": "float32"
+          }
+        ]
       }
     ]
   }

--- a/data/test/ops/xor.jsonc
+++ b/data/test/ops/xor.jsonc
@@ -48,6 +48,76 @@
             "type": "bool"
           }
         ]
+      },
+      {
+        "name": "Scalar T[2,2]",
+        "inputs": [
+          {
+            "data": [true],
+            "dims": [],
+            "type": "bool"
+          },
+          {
+            "data": [
+              false, false, false, false
+            ],
+            "dims": [2,2],
+            "type":"bool"
+          }
+        ],
+        "outputs": [
+          {
+            "data": [true, true, true, true],
+            "dims": [2,2],
+            "type": "bool"
+          }
+        ]
+      },
+      {
+        "name": "T[2,2] Scalar",
+        "inputs": [
+          {
+            "data": [
+              true, true, true, true
+            ],
+            "dims": [2,2],
+            "type":"bool"
+          },
+          {
+            "data": [false],
+            "dims": [],
+            "type": "bool"
+          }
+        ],
+        "outputs": [
+          {
+            "data": [true, true, true, true],
+            "dims": [2,2],
+            "type": "bool"
+          }
+        ]
+      },
+      {
+        "name": "Scalar Scalar",
+        "inputs": [
+          {
+            "data": [true],
+            "dims": [],
+            "type":"bool"
+          },
+          {
+            "data": [true],
+            "dims": [],
+            "type": "bool"
+          }
+        ],
+        "outputs": [
+          {
+            "data": [false],
+            "dims": [],
+            "type": "bool"
+          }
+        ]
       }
     ]
   }


### PR DESCRIPTION
* These test cases are required because ONNX.js will soon support scalar tensors